### PR TITLE
Fix fwd slash (post method)

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -11,7 +11,7 @@ class API {
     }
 
     async get(params) {
-        const { body } = await get(`${this.server}${this.path}/api.php`, {
+        const { body } = await get(`${this.server + this.path}/api.php`, {
             searchParams: {
                 ...params,
                 format: 'json'
@@ -32,7 +32,7 @@ class API {
     }
 
     async post(params) {
-        const { body } = await post(`${this.server}/${this.path}api.php`, {
+        const { body } = await post(`${this.server + this.path}/api.php`, {
             form: {
                 ...params,
                 format: 'json'


### PR DESCRIPTION
Based on api.php?action=query&meta=siteinfo general properties "server" and "scriptpath"

Remove templated redundancy